### PR TITLE
Fix SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "name": "Jordan Santell",
     "url": "http://github.com/jsantell"
   },
-  "license": "MPL 2.0",
+  "license": "MPL-2.0",
   "scripts": {
     "test": "./node_modules/.bin/mocha --reporter spec --ui bdd"
   },


### PR DESCRIPTION
According to https://spdx.org/licenses/ , the identifier should be "MPL-2.0" with a dash, not space.

This is done for easier license identification by automated license checker tools.